### PR TITLE
fix: filter_var(): Argument #3 ($options) must be of type array|int, …

### DIFF
--- a/src/Validate.php
+++ b/src/Validate.php
@@ -1001,7 +1001,7 @@ class Validate
             $param = null;
         }
 
-        return false !== filter_var($value, is_int($rule) ? $rule : filter_id($rule), $param);
+        return false !== filter_var($value, is_int($rule) ? $rule : filter_id($rule), $param ?? 0);
     }
 
     /**


### PR DESCRIPTION
…null given

in 8.0+